### PR TITLE
fix uncaught TypeError: Cannot read property 'querySelectorAll' of null

### DIFF
--- a/src/autofill-event.js
+++ b/src/autofill-event.js
@@ -25,7 +25,9 @@
     // setTimeout needed for Chrome as it fills other
     // form fields a little later...
     window.setTimeout(function() {
-      window.checkAndTriggerAutoFillEvent(findParentForm(target).querySelectorAll('input'));
+      var parentForm = findParentForm(target);
+      if (!parentForm) return;
+      window.checkAndTriggerAutoFillEvent(parentForm.querySelectorAll('input'));
     }, 20);
   });
 


### PR DESCRIPTION
@iamJoeTaylor alternative pr for #1 -- difference from #2 is that `findParentForm(target)` is executed only once.
